### PR TITLE
ci: run tests on windows and macos

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,6 +64,34 @@ jobs:
 
   test:
     name: Test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest]
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup cargo cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Run cargo test
+        run: cargo test --locked
+
+  test-coverage:
+    name: Test coverage
     runs-on: ubuntu-latest
 
     steps:
@@ -89,7 +117,6 @@ jobs:
       - name: Run cargo test
         run: cargo test --locked
         env:
-          CARGO_INCREMENTAL: 0
           RUSTFLAGS: -Cinstrument-coverage
           LLVM_PROFILE_FILE: ${{ github.workspace }}/target/coverage/git_mob-%p-%m.profraw
 


### PR DESCRIPTION
## Changes to build workflow
* Rename `test` job to `test-coverage` job: This runs tests on Ubuntu and uploads coverage to Codecov as before
* Add new `test` job which runs tests on both windows and macos
* Remove env `CARGO_INCREMENTAL=0` from `test-coverage` job
because it is set by default