### PR TITLE
ci: use latest windows 2025 agent

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, windows-latest]
+        os: [macos-latest, windows-2025]
 
     steps:
       - name: Checkout sources


### PR DESCRIPTION
One of the integration tests started failing in windows randomly https://github.com/Mubashwer/git-mob/actions/runs/14195441708/job/39769402549

Hoping this will fix it