### PR TITLE
test: fix `test_setup_local_given_hooks_dir_set_and_starts_with_tilde` integration test for windows ci

### DIFF
--- a/tests/setup.rs
+++ b/tests/setup.rs
@@ -103,7 +103,7 @@ Setup complete
 fn test_setup_global_given_hooks_dir_set_and_starts_with_tilde(
     ctx: TestContextRepo,
 ) -> Result<(), Box<dyn Error>> {
-    let hooks_dir = Path::new("~").join("my").join("githooks");
+    let hooks_dir = Path::new("~/my/githooks");
     let expanded_hooks_dir = ctx.home_dir.path().join("my").join("githooks");
 
     // setting global hooks directory
@@ -268,7 +268,7 @@ Setup complete
 fn test_setup_local_given_hooks_dir_set_and_starts_with_tilde(
     ctx: TestContextRepo,
 ) -> Result<(), Box<dyn Error>> {
-    let hooks_dir = Path::new("~").join("my").join("githooks");
+    let hooks_dir = Path::new("~/my/githooks");
     let expanded_hooks_dir = ctx.home_dir.path().join("my").join("githooks");
 
     // setting local hooks directory


### PR DESCRIPTION
Fix failing CI test `test_setup_local_given_hooks_dir_set_and_starts_with_tilde`
caused by Git's inability to expand tilde paths containing backslashes on Windows.

**Problem:**
- Tests were using `Path::new("~").join("my").join("githooks")` which creates
  platform-specific paths with backslashes on Windows (`~\my\githooks`)
- Git 2.49.0.windows.1 and possibly newer versions cannot expand tilde paths with
  backslashes, failing with "fatal: failed to expand user dir in: '~\\my\\githooks'"
- This caused Git config to return empty values instead of expanded paths,
  making tests fail in CI while passing locally with older Git versions

**Solution:**
- Changed both tilde path tests to use forward slash string literals:
  `Path::new("~/my/githooks")` instead of `Path::new("~").join("my").join("githooks")`
- Git can properly expand tilde paths with forward slashes on all platforms
- Production code is unaffected as it only uses absolute paths from `home_dir()`

**Tests Fixed:**
`test_setup_local_given_hooks_dir_set_and_starts_with_tilde`

**Impact:**
- All 76 tests now pass in both local and CI environments
- No functional changes to production code
- Improved cross-platform compatibility for test suite

Fixes the Git version-specific behavior where newer Windows Git requires
forward slashes in tilde paths for proper expansion.