### PR TITLE
feat: rename coauthor command to team-member for improved clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ $ cargo install git-mob-tool
 - Store your team members' details with keys
 
   ```console
-  $ git mob coauthor --add lm "Leo Messi" leo.messi@example.com
-  $ git mob coauthor --add em "Emi Martinez" emi.martinez@example.com
-  $ git mob coauthor --add sa "Sergio Aguero" sergio.aguero@example.com
+  $ git mob team-member --add lm "Leo Messi" leo.messi@example.com
+  $ git mob team-member --add em "Emi Martinez" emi.martinez@example.com
+  $ git mob team-member --add sa "Sergio Aguero" sergio.aguero@example.com
   ```
 
 ## Usage
@@ -77,7 +77,7 @@ $ cargo install git-mob-tool
   [↑↓ to move, space to select one, → to all, ← to none, type to filter ]
   ```
 
-  Alternatively, if you remember the co-author keys, you may bypass the multi-select menu by running:
+  Alternatively, if you remember the team member keys, you may bypass the multi-select menu by running:
 
   ```console
   $ git mob --with lm em

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,5 @@
 use crate::coauthor_repo::CoauthorRepo;
-use crate::commands::{coauthor::Coauthor, mob::Mob, setup::Setup};
+use crate::commands::{mob::Mob, setup::Setup, team_member::TeamMember};
 use clap::{Parser, Subcommand};
 use std::error::Error;
 use std::io::Write;
@@ -28,7 +28,7 @@ use std::str;
 ///
 /// git mob setup --global
 ///
-/// git mob coauthor --add lm "Leo Messi" leo.messi@example.com
+/// git mob team-member --add lm "Leo Messi" leo.messi@example.com
 ///
 /// git mob --with lm
 struct Cli {
@@ -42,11 +42,12 @@ struct Cli {
 enum Commands {
     /// Create prepare-commit-msg githook which append Co-authored-by trailers to commit message
     Setup(Setup),
-    /// Add/delete/list co-author(s) from co-author repository
+    /// Add/delete/list team member(s) from team member repository
     ///
-    /// User must store co-author(s) to co-author repository by using keys
+    /// User must store team member(s) to team member repository by using keys
     /// before starting pair/mob programming session(s).
-    Coauthor(Coauthor),
+    #[clap(alias = "coauthor")] // alias for backward compatibility
+    TeamMember(TeamMember),
 }
 
 pub fn run(coauthor_repo: &impl CoauthorRepo, out: &mut impl Write) -> Result<(), Box<dyn Error>> {
@@ -62,7 +63,7 @@ fn run_inner(
     match &cli.command {
         None => cli.mob.handle(coauthor_repo, out)?,
         Some(Commands::Setup(setup)) => setup.handle(out)?,
-        Some(Commands::Coauthor(coauthor)) => coauthor.handle(coauthor_repo, out)?,
+        Some(Commands::TeamMember(team_member)) => team_member.handle(coauthor_repo, out)?,
     }
     Ok(())
 }
@@ -100,7 +101,7 @@ mod tests {
     }
 
     #[test]
-    fn test_delete_coauthor() -> Result<(), Box<dyn Error>> {
+    fn test_delete_team_member() -> Result<(), Box<dyn Error>> {
         let key = "lm";
         let mut mock_coauthor_repo = MockCoauthorRepo::new();
         mock_coauthor_repo
@@ -115,7 +116,7 @@ mod tests {
             .returning(|_| Ok(()));
 
         let cli = Cli {
-            command: Some(Commands::Coauthor(Coauthor {
+            command: Some(Commands::TeamMember(TeamMember {
                 delete: Some(key.to_owned()),
                 add: None,
                 list: false,

--- a/src/commands/mob.rs
+++ b/src/commands/mob.rs
@@ -13,7 +13,7 @@ pub(crate) struct Mob {
     pub(crate) with: Option<Vec<String>>,
     /// Clears mob/pair programming session. Going solo!
     ///
-    /// Usage example: git mob co-author --list
+    /// Usage example: git mob --clear
     #[arg(short = 'c', long = "clear")]
     pub(crate) clear: bool,
     /// Lists co-author(s) in current mob/pair programming session
@@ -64,7 +64,7 @@ impl Mob {
                 let coauthors = coauthor_repo.list(false)?;
                 if coauthors.is_empty() {
                     return Err(
-                        "No co-author(s) found. At least one co-author must be added".into(),
+                        "No team member(s) found. At least one team member must be added".into(),
                     );
                 }
 
@@ -91,7 +91,7 @@ impl Mob {
                             coauthor_repo.add_to_mob(&coauthor)?;
                             coauthors.push(coauthor);
                         }
-                        None => return Err(format!("No co-author found with key: {key}").into()),
+                        None => return Err(format!("No team member found with key: {key}").into()),
                     }
                 }
 
@@ -241,7 +241,7 @@ mod tests {
     }
 
     #[test]
-    fn test_mob_with_given_no_coauthors_added() -> Result<(), Box<dyn Error>> {
+    fn test_mob_with_given_no_team_members_added() -> Result<(), Box<dyn Error>> {
         let coauthors = vec![];
 
         let mut mock_coauthor_repo = MockCoauthorRepo::new();
@@ -261,9 +261,8 @@ mod tests {
         let mut out = Vec::new();
         let result = mob_cmd.handle(&mock_coauthor_repo, &mut out);
 
-        assert!(result
-            .is_err_and(|err| err.to_string()
-                == *"No co-author(s) found. At least one co-author must be added"));
+        assert!(result.is_err_and(|err| err.to_string()
+            == *"No team member(s) found. At least one team member must be added"));
 
         Ok(())
     }
@@ -318,7 +317,7 @@ mod tests {
     }
 
     #[test]
-    fn test_mob_with_by_key_when_coauthor_not_found() -> Result<(), Box<dyn Error>> {
+    fn test_mob_with_by_key_when_team_member_not_found() -> Result<(), Box<dyn Error>> {
         let key = "lm";
 
         let mut mock_coauthor_repo = MockCoauthorRepo::new();
@@ -343,7 +342,7 @@ mod tests {
         let result = mob_cmd.handle(&mock_coauthor_repo, &mut out);
 
         assert!(result
-            .is_err_and(|err| err.to_string() == format!("No co-author found with key: {key}")));
+            .is_err_and(|err| err.to_string() == format!("No team member found with key: {key}")));
 
         Ok(())
     }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,3 @@
-pub(crate) mod coauthor;
 pub(crate) mod mob;
 pub(crate) mod setup;
+pub(crate) mod team_member;

--- a/tests/help.rs
+++ b/tests/help.rs
@@ -22,16 +22,16 @@ Usage example:
 
 git mob setup --global
 
-git mob coauthor --add lm "Leo Messi" leo.messi@example.com
+git mob team-member --add lm "Leo Messi" leo.messi@example.com
 
 git mob --with lm
 
 Usage: git mob [COMMAND] [OPTIONS]
 
 Commands:
-  setup     Create prepare-commit-msg githook which append Co-authored-by trailers to commit message
-  coauthor  Add/delete/list co-author(s) from co-author repository
-  help      Print this message or the help of the given subcommand(s)
+  setup        Create prepare-commit-msg githook which append Co-authored-by trailers to commit message
+  team-member  Add/delete/list team member(s) from team member repository
+  help         Print this message or the help of the given subcommand(s)
 
 Options:
   -w, --with [<COAUTHOR_KEY>...]
@@ -42,7 +42,7 @@ Options:
   -c, --clear
           Clears mob/pair programming session. Going solo!
           
-          Usage example: git mob co-author --list
+          Usage example: git mob --clear
 
   -l, --list
           Lists co-author(s) in current mob/pair programming session
@@ -78,9 +78,9 @@ r#"A CLI app which can help users automatically add co-author(s) to git commits 
 Usage: git mob [COMMAND] [OPTIONS]
 
 Commands:
-  setup     Create prepare-commit-msg githook which append Co-authored-by trailers to commit message
-  coauthor  Add/delete/list co-author(s) from co-author repository
-  help      Print this message or the help of the given subcommand(s)
+  setup        Create prepare-commit-msg githook which append Co-authored-by trailers to commit message
+  team-member  Add/delete/list team member(s) from team member repository
+  help         Print this message or the help of the given subcommand(s)
 
 Options:
   -w, --with [<COAUTHOR_KEY>...]  Sets active co-author(s) for pair/mob programming session
@@ -97,33 +97,33 @@ Options:
 
 #[test_context(TestContextCli, skip_teardown)]
 #[test]
-fn test_coauthor_help(ctx: TestContextCli) -> Result<(), Box<dyn Error>> {
+fn test_team_member_help(ctx: TestContextCli) -> Result<(), Box<dyn Error>> {
     ctx.git()
-        .args(["mob", "help", "coauthor"])
+        .args(["mob", "help", "team-member"])
         .assert()
         .success()
         .stdout(predicate::str::diff(
-r#"Add/delete/list co-author(s) from co-author repository
+r#"Add/delete/list team member(s) from team member repository
 
-User must store co-author(s) to co-author repository by using keys before starting pair/mob programming session(s).
+User must store team member(s) to team member repository by using keys before starting pair/mob programming session(s).
 
-Usage: git mob coauthor [OPTIONS]
+Usage: git mob team-member [OPTIONS]
 
 Options:
-  -a, --add <COAUTHOR_KEY> <COAUTHOR_NAME> <COAUTHOR_EMAIL>
-          Adds co-author to co-author repository
+  -a, --add <TEAM_MEMBER_KEY> <TEAM_MEMBER_NAME> <TEAM_MEMBER_EMAIL>
+          Adds team member to team member repository
           
-          Usage example: git mob coauthor --add lm "Leo Messi" leo.messi@example.com
+          Usage example: git mob team-member --add lm "Leo Messi" leo.messi@example.com
 
-  -d, --delete <COAUTHOR_KEY>
-          Remove co-author from co-author repository
+  -d, --delete <TEAM_MEMBER_KEY>
+          Remove team member from team member repository
           
-          Usage example: git mob coauthor --delete lm
+          Usage example: git mob team-member --delete lm
 
   -l, --list
-          Lists co-author(s) with keys(s) from co-author repository
+          Lists team member(s) with keys(s) from team member repository
           
-          Usage example: git mob coauthor --list
+          Usage example: git mob team-member --list
 
   -h, --help
           Print help (see a summary with '-h')
@@ -138,23 +138,23 @@ Options:
 
 #[test_context(TestContextCli, skip_teardown)]
 #[test]
-fn test_coauthor_help_summary(ctx: TestContextCli) -> Result<(), Box<dyn Error>> {
+fn test_team_member_help_summary(ctx: TestContextCli) -> Result<(), Box<dyn Error>> {
     ctx.git()
-        .args(["mob", "coauthor", "-h"])
+        .args(["mob", "team-member", "-h"])
         .assert()
         .success()
         .stdout(predicate::str::diff(
-            r#"Add/delete/list co-author(s) from co-author repository
+            r#"Add/delete/list team member(s) from team member repository
 
-Usage: git mob coauthor [OPTIONS]
+Usage: git mob team-member [OPTIONS]
 
 Options:
-  -a, --add <COAUTHOR_KEY> <COAUTHOR_NAME> <COAUTHOR_EMAIL>
-          Adds co-author to co-author repository
-  -d, --delete <COAUTHOR_KEY>
-          Remove co-author from co-author repository
+  -a, --add <TEAM_MEMBER_KEY> <TEAM_MEMBER_NAME> <TEAM_MEMBER_EMAIL>
+          Adds team member to team member repository
+  -d, --delete <TEAM_MEMBER_KEY>
+          Remove team member from team member repository
   -l, --list
-          Lists co-author(s) with keys(s) from co-author repository
+          Lists team member(s) with keys(s) from team member repository
   -h, --help
           Print help (see more with '--help')
   -V, --version

--- a/tests/mob.rs
+++ b/tests/mob.rs
@@ -11,7 +11,7 @@ use test_context::test_context;
 #[test_context(TestContextCli, skip_teardown)]
 #[test]
 fn test_mob_with_by_keys(ctx: TestContextCli) -> Result<(), Box<dyn Error>> {
-    add_two_coauthors(&ctx)?;
+    add_two_team_team_members(&ctx)?;
 
     // mobbing with both of the co-authors
     ctx.git()
@@ -36,13 +36,15 @@ fn test_mob_with_by_keys(ctx: TestContextCli) -> Result<(), Box<dyn Error>> {
 
 #[test_context(TestContextCli, skip_teardown)]
 #[test]
-fn test_mob_with_by_key_when_coauthor_not_found(ctx: TestContextCli) -> Result<(), Box<dyn Error>> {
+fn test_mob_with_by_key_when_team_member_not_found(
+    ctx: TestContextCli,
+) -> Result<(), Box<dyn Error>> {
     ctx.git()
         .args(["mob", "--with", "jk"])
         .assert()
         .failure()
         .stderr(predicate::str::diff(
-            "Error: \"No co-author found with key: jk\"\n",
+            "Error: \"No team member found with key: jk\"\n",
         ));
 
     Ok(())
@@ -50,7 +52,7 @@ fn test_mob_with_by_key_when_coauthor_not_found(ctx: TestContextCli) -> Result<(
 
 #[test_context(TestContextCli, skip_teardown)]
 #[test]
-fn test_mob_with_multiselect_given_no_coauthors_added(
+fn test_mob_with_multiselect_given_no_team_members_added(
     ctx: TestContextCli,
 ) -> Result<(), Box<dyn Error>> {
     // running command to display mob session multiselect prompt
@@ -59,7 +61,7 @@ fn test_mob_with_multiselect_given_no_coauthors_added(
         .assert()
         .failure()
         .stderr(predicate::str::diff(
-            "Error: \"No co-author(s) found. At least one co-author must be added\"\n",
+            "Error: \"No team member(s) found. At least one team member must be added\"\n",
         ));
 
     Ok(())
@@ -69,8 +71,8 @@ fn test_mob_with_multiselect_given_no_coauthors_added(
 #[test_context(TestContextCli, skip_teardown)]
 #[test]
 fn test_mob_with_multiselect_when_select_none(ctx: TestContextCli) -> Result<(), Box<dyn Error>> {
-    // given a mob session with 2 co-authors is active
-    add_two_coauthors(&ctx)?;
+    // given a mob session with 2 co-authors
+    add_two_team_team_members(&ctx)?;
     ctx.git()
         .args(["mob", "--with", "lm", "em"])
         .assert()
@@ -109,7 +111,7 @@ fn test_mob_with_multiselect_when_select_none(ctx: TestContextCli) -> Result<(),
 fn test_mob_with_multiselect_when_select_coauthor(
     ctx: TestContextCli,
 ) -> Result<(), Box<dyn Error>> {
-    add_two_coauthors(&ctx)?;
+    add_two_team_team_members(&ctx)?;
 
     // running command to display mob session multiselect prompt
     let mut command = ctx.git();
@@ -142,8 +144,8 @@ fn test_mob_with_multiselect_when_select_coauthor(
 #[test_context(TestContextCli, skip_teardown)]
 #[test]
 fn test_mob_with_multiselect_when_press_escape(ctx: TestContextCli) -> Result<(), Box<dyn Error>> {
-    // given a mob session  with 2 co-authors is active
-    add_two_coauthors(&ctx)?;
+    // given a mob session with 2 co-authors
+    add_two_team_team_members(&ctx)?;
     ctx.git()
         .args(["mob", "--with", "lm", "em"])
         .assert()
@@ -181,9 +183,9 @@ fn test_mob_with_multiselect_when_press_escape(ctx: TestContextCli) -> Result<()
 #[test_context(TestContextCli, skip_teardown)]
 #[test]
 fn test_clear_mob(ctx: TestContextCli) -> Result<(), Box<dyn Error>> {
-    add_two_coauthors(&ctx)?;
+    add_two_team_team_members(&ctx)?;
 
-    // mobbing with both of the co-authors
+    // mobbing with both of the team members
     ctx.git()
         .args(["mob", "--with", "lm", "em"])
         .assert()
@@ -232,9 +234,9 @@ fn test_clear_mob_given_empty_mob_session(ctx: TestContextCli) -> Result<(), Box
 #[test_context(TestContextCli, skip_teardown)]
 #[test]
 fn test_mob_coauthor_trailers(ctx: TestContextCli) -> Result<(), Box<dyn Error>> {
-    add_two_coauthors(&ctx)?;
+    add_two_team_team_members(&ctx)?;
 
-    // mobbing with both of the co-authors
+    // mobbing with both of the team members
     ctx.git()
         .args(["mob", "--with", "lm", "em"])
         .assert()
@@ -243,7 +245,7 @@ fn test_mob_coauthor_trailers(ctx: TestContextCli) -> Result<(), Box<dyn Error>>
             "Leo Messi <leo.messi@example.com>\nEmi Martinez <emi.martinez@example.com>\n",
         ));
 
-    // verifying mob co-author trailers show Co-authored-by trailers for both co-authors
+    // verifying mob co-author trailers show Co-authored-by trailers for both team members
     ctx.git()
         .args(["mob", "--trailers"])
         .assert()
@@ -283,11 +285,11 @@ fn test_list_mob_given_empty_mob_session(ctx: TestContextCli) -> Result<(), Box<
     Ok(())
 }
 
-fn add_two_coauthors(ctx: &TestContextCli) -> Result<(), Box<dyn Error>> {
+fn add_two_team_team_members(ctx: &TestContextCli) -> Result<(), Box<dyn Error>> {
     ctx.git()
         .args([
             "mob",
-            "coauthor",
+            "team-member",
             "--add",
             "lm",
             "Leo Messi",
@@ -299,7 +301,7 @@ fn add_two_coauthors(ctx: &TestContextCli) -> Result<(), Box<dyn Error>> {
     ctx.git()
         .args([
             "mob",
-            "coauthor",
+            "team-member",
             "--add",
             "em",
             "Emi Martinez",

--- a/tests/mob.rs
+++ b/tests/mob.rs
@@ -11,7 +11,7 @@ use test_context::test_context;
 #[test_context(TestContextCli, skip_teardown)]
 #[test]
 fn test_mob_with_by_keys(ctx: TestContextCli) -> Result<(), Box<dyn Error>> {
-    add_two_team_team_members(&ctx)?;
+    add_two_team_members(&ctx)?;
 
     // mobbing with both of the co-authors
     ctx.git()
@@ -72,7 +72,7 @@ fn test_mob_with_multiselect_given_no_team_members_added(
 #[test]
 fn test_mob_with_multiselect_when_select_none(ctx: TestContextCli) -> Result<(), Box<dyn Error>> {
     // given a mob session with 2 co-authors
-    add_two_team_team_members(&ctx)?;
+    add_two_team_members(&ctx)?;
     ctx.git()
         .args(["mob", "--with", "lm", "em"])
         .assert()
@@ -111,7 +111,7 @@ fn test_mob_with_multiselect_when_select_none(ctx: TestContextCli) -> Result<(),
 fn test_mob_with_multiselect_when_select_coauthor(
     ctx: TestContextCli,
 ) -> Result<(), Box<dyn Error>> {
-    add_two_team_team_members(&ctx)?;
+    add_two_team_members(&ctx)?;
 
     // running command to display mob session multiselect prompt
     let mut command = ctx.git();
@@ -145,7 +145,7 @@ fn test_mob_with_multiselect_when_select_coauthor(
 #[test]
 fn test_mob_with_multiselect_when_press_escape(ctx: TestContextCli) -> Result<(), Box<dyn Error>> {
     // given a mob session with 2 co-authors
-    add_two_team_team_members(&ctx)?;
+    add_two_team_members(&ctx)?;
     ctx.git()
         .args(["mob", "--with", "lm", "em"])
         .assert()
@@ -183,7 +183,7 @@ fn test_mob_with_multiselect_when_press_escape(ctx: TestContextCli) -> Result<()
 #[test_context(TestContextCli, skip_teardown)]
 #[test]
 fn test_clear_mob(ctx: TestContextCli) -> Result<(), Box<dyn Error>> {
-    add_two_team_team_members(&ctx)?;
+    add_two_team_members(&ctx)?;
 
     // mobbing with both of the team members
     ctx.git()
@@ -234,7 +234,7 @@ fn test_clear_mob_given_empty_mob_session(ctx: TestContextCli) -> Result<(), Box
 #[test_context(TestContextCli, skip_teardown)]
 #[test]
 fn test_mob_coauthor_trailers(ctx: TestContextCli) -> Result<(), Box<dyn Error>> {
-    add_two_team_team_members(&ctx)?;
+    add_two_team_members(&ctx)?;
 
     // mobbing with both of the team members
     ctx.git()
@@ -285,7 +285,7 @@ fn test_list_mob_given_empty_mob_session(ctx: TestContextCli) -> Result<(), Box<
     Ok(())
 }
 
-fn add_two_team_team_members(ctx: &TestContextCli) -> Result<(), Box<dyn Error>> {
+fn add_two_team_members(ctx: &TestContextCli) -> Result<(), Box<dyn Error>> {
     ctx.git()
         .args([
             "mob",

--- a/tests/prepare_commit_msg.rs
+++ b/tests/prepare_commit_msg.rs
@@ -15,11 +15,11 @@ fn test_prepare_commit_msg(ctx: TestContextRepo) -> Result<(), Box<dyn Error>> {
         .assert()
         .success();
 
-    // adding 2 co-authors
+    // adding 2 team members
     ctx.git()
         .args([
             "mob",
-            "coauthor",
+            "team-member",
             "--add",
             "lm",
             "Leo Messi",
@@ -31,7 +31,7 @@ fn test_prepare_commit_msg(ctx: TestContextRepo) -> Result<(), Box<dyn Error>> {
     ctx.git()
         .args([
             "mob",
-            "coauthor",
+            "team-member",
             "--add",
             "em",
             "Emi Martinez",
@@ -40,7 +40,7 @@ fn test_prepare_commit_msg(ctx: TestContextRepo) -> Result<(), Box<dyn Error>> {
         .assert()
         .success();
 
-    // mobbing with both of the co-authors
+    // mobbing with both of the team members
     ctx.git()
         .args(["mob", "--with", "lm", "em"])
         .assert()
@@ -103,11 +103,11 @@ fn test_prepare_commit_msg_given_local_hooks_directory(
         .assert()
         .success();
 
-    // adding 2 co-authors
+    // adding 2 team members
     ctx.git()
         .args([
             "mob",
-            "coauthor",
+            "team-member",
             "--add",
             "lm",
             "Leo Messi",
@@ -119,7 +119,7 @@ fn test_prepare_commit_msg_given_local_hooks_directory(
     ctx.git()
         .args([
             "mob",
-            "coauthor",
+            "team-member",
             "--add",
             "em",
             "Emi Martinez",
@@ -128,7 +128,7 @@ fn test_prepare_commit_msg_given_local_hooks_directory(
         .assert()
         .success();
 
-    // mobbing with both of the co-authors
+    // mobbing with both of the team members
     ctx.git()
         .args(["mob", "--with", "lm", "em"])
         .assert()

--- a/tests/team_member.rs
+++ b/tests/team_member.rs
@@ -8,12 +8,12 @@ use test_context::test_context;
 
 #[test_context(TestContextCli, skip_teardown)]
 #[test]
-fn test_add_and_list_coauthors(ctx: TestContextCli) -> Result<(), Box<dyn Error>> {
-    // adding 2 co-authors
+fn test_add_and_list_team_members(ctx: TestContextCli) -> Result<(), Box<dyn Error>> {
+    // adding 2 team members
     ctx.git()
         .args([
             "mob",
-            "coauthor",
+            "team-member",
             "--add",
             "lm",
             "Leo Messi",
@@ -26,7 +26,7 @@ fn test_add_and_list_coauthors(ctx: TestContextCli) -> Result<(), Box<dyn Error>
     ctx.git()
         .args([
             "mob",
-            "coauthor",
+            "team-member",
             "--add",
             "em",
             "Emi Martinez",
@@ -38,9 +38,9 @@ fn test_add_and_list_coauthors(ctx: TestContextCli) -> Result<(), Box<dyn Error>
             "Emi Martinez <emi.martinez@example.com>\n",
         ));
 
-    // co-authors list shows the 2 co-authors that were added
+    // team members list shows the 2 team members that were added
     ctx.git()
-        .args(["mob", "coauthor", "--list"])
+        .args(["mob", "team-member", "--list"])
         .assert()
         .success()
         .stdout(predicate::str::diff(
@@ -52,11 +52,11 @@ fn test_add_and_list_coauthors(ctx: TestContextCli) -> Result<(), Box<dyn Error>
 
 #[test_context(TestContextCli, skip_teardown)]
 #[test]
-fn test_add_coauthor_with_invalid_key(ctx: TestContextCli) -> Result<(), Box<dyn Error>> {
+fn test_add_member_with_invalid_key(ctx: TestContextCli) -> Result<(), Box<dyn Error>> {
     ctx.git()
         .args([
             "mob",
-            "coauthor",
+            "team-member",
             "--add",
             "invalid_key_with_underscore",
             "Leo Messi",
@@ -73,9 +73,11 @@ fn test_add_coauthor_with_invalid_key(ctx: TestContextCli) -> Result<(), Box<dyn
 
 #[test_context(TestContextCli, skip_teardown)]
 #[test]
-fn test_list_coauthors_given_no_coauthors_added(ctx: TestContextCli) -> Result<(), Box<dyn Error>> {
+fn test_list_team_members_given_no_team_members_added(
+    ctx: TestContextCli,
+) -> Result<(), Box<dyn Error>> {
     ctx.git()
-        .args(["mob", "coauthor", "--list"])
+        .args(["mob", "team-member", "--list"])
         .assert()
         .success()
         .stdout(predicate::str::diff(""));
@@ -85,12 +87,12 @@ fn test_list_coauthors_given_no_coauthors_added(ctx: TestContextCli) -> Result<(
 
 #[test_context(TestContextCli, skip_teardown)]
 #[test]
-fn test_delete_coauthor(ctx: TestContextCli) -> Result<(), Box<dyn Error>> {
-    // adding 2 co-authors
+fn test_delete_team_members(ctx: TestContextCli) -> Result<(), Box<dyn Error>> {
+    // adding 2 team members
     ctx.git()
         .args([
             "mob",
-            "coauthor",
+            "team-member",
             "--add",
             "lm",
             "Leo Messi",
@@ -102,7 +104,7 @@ fn test_delete_coauthor(ctx: TestContextCli) -> Result<(), Box<dyn Error>> {
     ctx.git()
         .args([
             "mob",
-            "coauthor",
+            "team-member",
             "--add",
             "em",
             "Emi Martinez",
@@ -111,15 +113,15 @@ fn test_delete_coauthor(ctx: TestContextCli) -> Result<(), Box<dyn Error>> {
         .assert()
         .success();
 
-    // deleting one co-author
+    // deleting one team member
     ctx.git()
-        .args(["mob", "coauthor", "--delete", "lm"])
+        .args(["mob", "team-member", "--delete", "lm"])
         .assert()
         .success();
 
-    // co-authors list excludes the deleted co-author
+    // team members list excludes the deleted team member
     ctx.git()
-        .args(["mob", "coauthor", "--list"])
+        .args(["mob", "team-member", "--list"])
         .assert()
         .success()
         .stdout(predicate::str::diff(
@@ -131,13 +133,13 @@ fn test_delete_coauthor(ctx: TestContextCli) -> Result<(), Box<dyn Error>> {
 
 #[test_context(TestContextCli, skip_teardown)]
 #[test]
-fn test_delete_coauthor_when_coauthor_not_found(ctx: TestContextCli) -> Result<(), Box<dyn Error>> {
+fn test_delete_member_when_member_not_found(ctx: TestContextCli) -> Result<(), Box<dyn Error>> {
     ctx.git()
-        .args(["mob", "coauthor", "--delete", "lm"])
+        .args(["mob", "team-member", "--delete", "lm"])
         .assert()
         .failure()
         .stderr(predicate::str::diff(
-            "Error: \"No co-author found with key: lm\"\n",
+            "Error: \"No team member found with key: lm\"\n",
         ));
 
     Ok(())


### PR DESCRIPTION
The `team-member` command name better communicates that it manages the repository of available team members, while the old `coauthor` name was ambiguous about whether it managed the team member repository or the active mob session.

Examples:
- `git mob team-member --add` clearly indicates adding to team roster
- `git mob coauthor --add` was unclear (adding to roster vs. session?)

Maintains backward compatibility with `coauthor` alias.