### PR TITLE
feat: make --global the default behavior for setup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ $ cargo install git-mob-tool
 - Set up a global [`prepare-commit-msg`](https://git-scm.com/docs/githooks#_prepare_commit_msg) githook which appends the `Co-authored-by` trailers to the commit message.
 
   ```console
-  $ git mob setup --global
+  $ git mob setup
   ```
 
   If a repository overrides `core.hooksPath` git configuration variable (e.g when using husky), then you will additionally need to run `git mob setup --local` for each such repository. This will set up a local (repository-specific) `prepare-commit-msg` githook which invokes the global one.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -26,7 +26,7 @@ use std::str;
 ///
 /// Usage example:
 ///
-/// git mob setup --global
+/// git mob setup
 ///
 /// git mob team-member --add lm "Leo Messi" leo.messi@example.com
 ///
@@ -40,7 +40,7 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Create prepare-commit-msg githook which append Co-authored-by trailers to commit message
+    /// Create global prepare-commit-msg githook which append Co-authored-by trailers to commit message
     Setup(Setup),
     /// Add/delete/list team member(s) from team member repository
     ///

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -40,7 +40,7 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Create global prepare-commit-msg githook which append Co-authored-by trailers to commit message
+    /// Create global prepare-commit-msg githook which appends Co-authored-by trailers to commit message
     Setup(Setup),
     /// Add/delete/list team member(s) from team member repository
     ///

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -10,12 +10,12 @@ use clap::Parser;
 use home::home_dir;
 
 #[derive(Parser)]
-#[command(arg_required_else_help = true)]
 pub(crate) struct Setup {
-    /// Set up global prepare-commit-msg githook
+    /// Set up global prepare-commit-msg githook (deprecated, now default)
     ///
     /// Usage example: git mob setup --global
-    #[arg(short = 'g', long = "global")]
+    #[arg(short = 'g', long = "global", hide = true)]
+    // This option exists only for backward compatibility as global is now the default behavior
     pub(crate) global: bool,
     /// Set up local prepare-commit-msg githook which invokes the global one
     ///
@@ -28,12 +28,10 @@ pub(crate) struct Setup {
 
 impl Setup {
     pub(crate) fn handle(&self, out: &mut impl Write) -> Result<(), Box<dyn Error>> {
-        if self.global {
-            self.handle_global(out)?;
-        }
-
         if self.local {
             self.handle_local(out)?;
+        } else {
+            self.handle_global(out)?;
         }
 
         Ok(())

--- a/tests/help.rs
+++ b/tests/help.rs
@@ -29,7 +29,7 @@ git mob --with lm
 Usage: git mob [COMMAND] [OPTIONS]
 
 Commands:
-  setup        Create global prepare-commit-msg githook which append Co-authored-by trailers to commit message
+  setup        Create global prepare-commit-msg githook which appends Co-authored-by trailers to commit message
   team-member  Add/delete/list team member(s) from team member repository
   help         Print this message or the help of the given subcommand(s)
 
@@ -78,7 +78,7 @@ r#"A CLI app which can help users automatically add co-author(s) to git commits 
 Usage: git mob [COMMAND] [OPTIONS]
 
 Commands:
-  setup        Create global prepare-commit-msg githook which append Co-authored-by trailers to commit message
+  setup        Create global prepare-commit-msg githook which appends Co-authored-by trailers to commit message
   team-member  Add/delete/list team member(s) from team member repository
   help         Print this message or the help of the given subcommand(s)
 
@@ -173,7 +173,7 @@ fn test_setup_help(ctx: TestContextCli) -> Result<(), Box<dyn Error>> {
         .assert()
         .success()
         .stdout(predicate::str::diff(
-r#"Create global prepare-commit-msg githook which append Co-authored-by trailers to commit message
+r#"Create global prepare-commit-msg githook which appends Co-authored-by trailers to commit message
 
 Usage: git mob setup [OPTIONS]
 
@@ -204,7 +204,7 @@ fn test_setup_help_summary(ctx: TestContextCli) -> Result<(), Box<dyn Error>> {
         .assert()
         .success()
         .stdout(predicate::str::diff(
-            r#"Create global prepare-commit-msg githook which append Co-authored-by trailers to commit message
+            r#"Create global prepare-commit-msg githook which appends Co-authored-by trailers to commit message
 
 Usage: git mob setup [OPTIONS]
 

--- a/tests/help.rs
+++ b/tests/help.rs
@@ -20,7 +20,7 @@ A user can attribute a git commit to more than one author by adding one or more 
 
 Usage example:
 
-git mob setup --global
+git mob setup
 
 git mob team-member --add lm "Leo Messi" leo.messi@example.com
 
@@ -29,7 +29,7 @@ git mob --with lm
 Usage: git mob [COMMAND] [OPTIONS]
 
 Commands:
-  setup        Create prepare-commit-msg githook which append Co-authored-by trailers to commit message
+  setup        Create global prepare-commit-msg githook which append Co-authored-by trailers to commit message
   team-member  Add/delete/list team member(s) from team member repository
   help         Print this message or the help of the given subcommand(s)
 
@@ -78,7 +78,7 @@ r#"A CLI app which can help users automatically add co-author(s) to git commits 
 Usage: git mob [COMMAND] [OPTIONS]
 
 Commands:
-  setup        Create prepare-commit-msg githook which append Co-authored-by trailers to commit message
+  setup        Create global prepare-commit-msg githook which append Co-authored-by trailers to commit message
   team-member  Add/delete/list team member(s) from team member repository
   help         Print this message or the help of the given subcommand(s)
 
@@ -173,16 +173,11 @@ fn test_setup_help(ctx: TestContextCli) -> Result<(), Box<dyn Error>> {
         .assert()
         .success()
         .stdout(predicate::str::diff(
-r#"Create prepare-commit-msg githook which append Co-authored-by trailers to commit message
+r#"Create global prepare-commit-msg githook which append Co-authored-by trailers to commit message
 
 Usage: git mob setup [OPTIONS]
 
 Options:
-  -g, --global
-          Set up global prepare-commit-msg githook
-          
-          Usage example: git mob setup --global
-
       --local
           Set up local prepare-commit-msg githook which invokes the global one
           
@@ -209,12 +204,11 @@ fn test_setup_help_summary(ctx: TestContextCli) -> Result<(), Box<dyn Error>> {
         .assert()
         .success()
         .stdout(predicate::str::diff(
-            r#"Create prepare-commit-msg githook which append Co-authored-by trailers to commit message
+            r#"Create global prepare-commit-msg githook which append Co-authored-by trailers to commit message
 
 Usage: git mob setup [OPTIONS]
 
 Options:
-  -g, --global   Set up global prepare-commit-msg githook
       --local    Set up local prepare-commit-msg githook which invokes the global one
   -h, --help     Print help (see more with '--help')
   -V, --version  Print version

--- a/tests/setup.rs
+++ b/tests/setup.rs
@@ -9,11 +9,11 @@ use test_context::test_context;
 
 #[test_context(TestContextRepo, skip_teardown)]
 #[test]
-fn test_setup_global_given_hooks_dir_not_set(ctx: TestContextRepo) -> Result<(), Box<dyn Error>> {
+fn test_setup_given_hooks_dir_not_set(ctx: TestContextRepo) -> Result<(), Box<dyn Error>> {
     let hooks_dir = ctx.home_dir.path().join(".git").join("hooks");
 
     ctx.git()
-        .args(["mob", "setup", "--global"])
+        .args(["mob", "setup"])
         .assert()
         .success()
         .stdout(predicate::str::diff(format!(
@@ -30,9 +30,7 @@ Setup complete
 
 #[test_context(TestContextRepo, skip_teardown)]
 #[test]
-fn test_setup_global_given_hooks_dir_set_and_exists(
-    ctx: TestContextRepo,
-) -> Result<(), Box<dyn Error>> {
+fn test_setup_given_hooks_dir_set_and_exists(ctx: TestContextRepo) -> Result<(), Box<dyn Error>> {
     let temp_dir = TempDir::new()?;
     let hooks_dir = temp_dir.path().to_path_buf();
 
@@ -48,7 +46,7 @@ fn test_setup_global_given_hooks_dir_set_and_exists(
         .success();
 
     ctx.git()
-        .args(["mob", "setup", "--global"])
+        .args(["mob", "setup"])
         .assert()
         .success()
         .stdout(predicate::str::diff(format!(
@@ -63,7 +61,7 @@ Setup complete
 
 #[test_context(TestContextRepo, skip_teardown)]
 #[test]
-fn test_setup_global_given_hooks_dir_set_but_does_not_exist(
+fn test_setup_given_hooks_dir_set_but_does_not_exist(
     ctx: TestContextRepo,
 ) -> Result<(), Box<dyn Error>> {
     let temp_dir = TempDir::new()?;
@@ -85,7 +83,7 @@ fn test_setup_global_given_hooks_dir_set_but_does_not_exist(
     assert!(!hooks_dir.exists());
 
     ctx.git()
-        .args(["mob", "setup", "--global"])
+        .args(["mob", "setup"])
         .assert()
         .success()
         .stdout(predicate::str::diff(format!(
@@ -100,7 +98,7 @@ Setup complete
 
 #[test_context(TestContextRepo, skip_teardown)]
 #[test]
-fn test_setup_global_given_hooks_dir_set_and_starts_with_tilde(
+fn test_setup_given_hooks_dir_set_and_starts_with_tilde(
     ctx: TestContextRepo,
 ) -> Result<(), Box<dyn Error>> {
     let hooks_dir = Path::new("~/my/githooks");
@@ -118,7 +116,7 @@ fn test_setup_global_given_hooks_dir_set_and_starts_with_tilde(
         .success();
 
     ctx.git()
-        .args(["mob", "setup", "--global"])
+        .args(["mob", "setup"])
         .assert()
         .success()
         .stdout(predicate::str::diff(format!(
@@ -135,7 +133,7 @@ Setup complete
 
 #[test_context(TestContextRepo, skip_teardown)]
 #[test]
-fn test_setup_global_given_prepare_commit_msg_hook_already_exists(
+fn test_setup_given_prepare_commit_msg_hook_already_exists(
     ctx: TestContextRepo,
 ) -> Result<(), Box<dyn Error>> {
     let temp_dir = TempDir::new()?;
@@ -159,7 +157,7 @@ fn test_setup_global_given_prepare_commit_msg_hook_already_exists(
         .success();
 
     ctx.git()
-        .args(["mob", "setup", "--global"])
+        .args(["mob", "setup"])
         .assert()
         .success()
         .stdout(predicate::str::diff(format!(


### PR DESCRIPTION
Previously, the setup command required explicit --global or --local flags and would show help when no arguments were provided. This change makes --global the default behavior, simplifying the common use case while maintaining backward compatibility.

Changes:
- Remove arg_required_else_help constraint from Setup command
- Make setup command default to global behavior when no flags specified
- Hide --global flag from help output while keeping it functional for backward compatibility
- Update command description to clarify global setup is default
- Update all documentation examples from "git mob setup --global" to "git mob setup"

The --global flag is still accepted but hidden from help output to avoid confusion while ensuring existing scripts and workflows continue to work. The --local flag remains unchanged and is only needed for repositories that override core.hooksPath (e.g., when using husky).

This aligns with user expectations since global setup was the standard installation method, with local setup being a specialized use case for repositories with custom hook configurations.