### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/Mubashwer/git-mob/security/code-scanning/1](https://github.com/Mubashwer/git-mob/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the root of the workflow file. This block will define the minimal permissions required for the workflow to function. Since the workflow primarily involves building, testing, and auditing code, it does not appear to require write access to the repository. We will set `contents: read` as the default permission for all jobs. If any job requires additional permissions, they can be specified individually within that job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
